### PR TITLE
Update multi-platform-build-test.yml

### DIFF
--- a/.github/workflows/multi-platform-build-test.yml
+++ b/.github/workflows/multi-platform-build-test.yml
@@ -58,7 +58,7 @@ jobs:
     
     - name: Install GLFW dependencies
       if: runner.os == 'Linux'
-      run: sudo apt install libwayland-dev libxkbcommon-dev xorg-dev
+      run: sudo apt update; sudo apt install libwayland-dev libxkbcommon-dev xorg-dev
          
       
         


### PR DESCRIPTION
Edited `Install GLFW dependencies` step to run `apt update` before installing. 

I really don't know how it worked before. Must depend on the runner.